### PR TITLE
Add CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR to claude env

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,7 @@
 {
+  "env": {
+      "CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR": "true"
+  },
   "permissions": {
     "allow": [
       "Bash(mkdir:*)",


### PR DESCRIPTION
Sometimes Claude decides to change the working directory and hooks stop working. Setting this variable restores the directory after each hook.