### PR TITLE
Switch to JSONL format logs (instead of JSON)

### DIFF
--- a/.claude/hooks/notification.py
+++ b/.claude/hooks/notification.py
@@ -92,28 +92,15 @@ def main():
         # Read JSON input from stdin
         input_data = json.loads(sys.stdin.read())
         
-        # Ensure log directory exists
-        import os
-        log_dir = os.path.join(os.getcwd(), 'logs')
-        os.makedirs(log_dir, exist_ok=True)
-        log_file = os.path.join(log_dir, 'notification.json')
+        # Ensure logs directory exists
+        log_dir = Path("logs")
+        log_dir.mkdir(parents=True, exist_ok=True)
+        log_file = log_dir / 'notification.jsonl'
         
-        # Read existing log data or initialize empty list
-        if os.path.exists(log_file):
-            with open(log_file, 'r') as f:
-                try:
-                    log_data = json.load(f)
-                except (json.JSONDecodeError, ValueError):
-                    log_data = []
-        else:
-            log_data = []
-        
-        # Append new data
-        log_data.append(input_data)
-        
-        # Write back to file with formatting
-        with open(log_file, 'w') as f:
-            json.dump(log_data, f, indent=2)
+        # Append new data as a single line to JSONL file
+        with open(log_file, 'a') as f:
+            json.dump(input_data, f)
+            f.write('\n')
         
         # Announce notification via TTS only if --notify flag is set
         # Skip TTS for the generic "Claude is waiting for your input" message

--- a/.claude/hooks/post_tool_use.py
+++ b/.claude/hooks/post_tool_use.py
@@ -13,27 +13,15 @@ def main():
         # Read JSON input from stdin
         input_data = json.load(sys.stdin)
         
-        # Ensure log directory exists
-        log_dir = Path.cwd() / 'logs'
+        # Ensure logs directory exists
+        log_dir = Path("logs")
         log_dir.mkdir(parents=True, exist_ok=True)
-        log_path = log_dir / 'post_tool_use.json'
+        log_file = log_dir / 'post_tool_use.jsonl'
         
-        # Read existing log data or initialize empty list
-        if log_path.exists():
-            with open(log_path, 'r') as f:
-                try:
-                    log_data = json.load(f)
-                except (json.JSONDecodeError, ValueError):
-                    log_data = []
-        else:
-            log_data = []
-        
-        # Append new data
-        log_data.append(input_data)
-        
-        # Write back to file with formatting
-        with open(log_path, 'w') as f:
-            json.dump(log_data, f, indent=2)
+        # Append new data as a single line to JSONL file
+        with open(log_file, 'a') as f:
+            json.dump(input_data, f)
+            f.write('\n')
         
         sys.exit(0)
         

--- a/.claude/hooks/pre_compact.py
+++ b/.claude/hooks/pre_compact.py
@@ -25,24 +25,12 @@ def log_pre_compact(input_data):
     # Ensure logs directory exists
     log_dir = Path("logs")
     log_dir.mkdir(parents=True, exist_ok=True)
-    log_file = log_dir / 'pre_compact.json'
+    log_file = log_dir / 'pre_compact.jsonl'
     
-    # Read existing log data or initialize empty list
-    if log_file.exists():
-        with open(log_file, 'r') as f:
-            try:
-                log_data = json.load(f)
-            except (json.JSONDecodeError, ValueError):
-                log_data = []
-    else:
-        log_data = []
-    
-    # Append the entire input data
-    log_data.append(input_data)
-    
-    # Write back to file with formatting
-    with open(log_file, 'w') as f:
-        json.dump(log_data, f, indent=2)
+    # Append new data as a single line to JSONL file
+    with open(log_file, 'a') as f:
+        json.dump(input_data, f)
+        f.write('\n')
 
 
 def backup_transcript(transcript_path, trigger):

--- a/.claude/hooks/pre_tool_use.py
+++ b/.claude/hooks/pre_tool_use.py
@@ -104,27 +104,15 @@ def main():
                 print("BLOCKED: Dangerous rm command detected and prevented", file=sys.stderr)
                 sys.exit(2)  # Exit code 2 blocks tool call and shows error to Claude
         
-        # Ensure log directory exists
-        log_dir = Path.cwd() / 'logs'
+        # Ensure logs directory exists
+        log_dir = Path("logs")
         log_dir.mkdir(parents=True, exist_ok=True)
-        log_path = log_dir / 'pre_tool_use.json'
+        log_file = log_dir / 'pre_tool_use.jsonl'
         
-        # Read existing log data or initialize empty list
-        if log_path.exists():
-            with open(log_path, 'r') as f:
-                try:
-                    log_data = json.load(f)
-                except (json.JSONDecodeError, ValueError):
-                    log_data = []
-        else:
-            log_data = []
-        
-        # Append new data
-        log_data.append(input_data)
-        
-        # Write back to file with formatting
-        with open(log_path, 'w') as f:
-            json.dump(log_data, f, indent=2)
+        # Append new data as a single line to JSONL file
+        with open(log_file, 'a') as f:
+            json.dump(input_data, f)
+            f.write('\n')
         
         sys.exit(0)
         

--- a/.claude/hooks/session_start.py
+++ b/.claude/hooks/session_start.py
@@ -26,24 +26,12 @@ def log_session_start(input_data):
     # Ensure logs directory exists
     log_dir = Path("logs")
     log_dir.mkdir(parents=True, exist_ok=True)
-    log_file = log_dir / 'session_start.json'
+    log_file = log_dir / 'session_start.jsonl'
     
-    # Read existing log data or initialize empty list
-    if log_file.exists():
-        with open(log_file, 'r') as f:
-            try:
-                log_data = json.load(f)
-            except (json.JSONDecodeError, ValueError):
-                log_data = []
-    else:
-        log_data = []
-    
-    # Append the entire input data
-    log_data.append(input_data)
-    
-    # Write back to file with formatting
-    with open(log_file, 'w') as f:
-        json.dump(log_data, f, indent=2)
+    # Append new data as a single line to JSONL file
+    with open(log_file, 'a') as f:
+        json.dump(input_data, f)
+        f.write('\n')
 
 
 def get_git_status():

--- a/.claude/hooks/stop.py
+++ b/.claude/hooks/stop.py
@@ -152,27 +152,15 @@ def main():
         session_id = input_data.get("session_id", "")
         stop_hook_active = input_data.get("stop_hook_active", False)
 
-        # Ensure log directory exists
-        log_dir = os.path.join(os.getcwd(), "logs")
-        os.makedirs(log_dir, exist_ok=True)
-        log_path = os.path.join(log_dir, "stop.json")
+        # Ensure logs directory exists
+        log_dir = Path("logs")
+        log_dir.mkdir(parents=True, exist_ok=True)
+        log_file = log_dir / 'stop.jsonl'
 
-        # Read existing log data or initialize empty list
-        if os.path.exists(log_path):
-            with open(log_path, 'r') as f:
-                try:
-                    log_data = json.load(f)
-                except (json.JSONDecodeError, ValueError):
-                    log_data = []
-        else:
-            log_data = []
-        
-        # Append new data
-        log_data.append(input_data)
-        
-        # Write back to file with formatting
-        with open(log_path, 'w') as f:
-            json.dump(log_data, f, indent=2)
+        # Append new data as a single line to JSONL file
+        with open(log_file, 'a') as f:
+            json.dump(input_data, f)
+            f.write('\n')
         
         # Handle --chat switch
         if args.chat and 'transcript_path' in input_data:

--- a/.claude/hooks/subagent_stop.py
+++ b/.claude/hooks/subagent_stop.py
@@ -90,27 +90,15 @@ def main():
         session_id = input_data.get("session_id", "")
         stop_hook_active = input_data.get("stop_hook_active", False)
 
-        # Ensure log directory exists
-        log_dir = os.path.join(os.getcwd(), "logs")
-        os.makedirs(log_dir, exist_ok=True)
-        log_path = os.path.join(log_dir, "subagent_stop.json")
+        # Ensure logs directory exists
+        log_dir = Path("logs")
+        log_dir.mkdir(parents=True, exist_ok=True)
+        log_file = log_dir / 'subagent_stop.jsonl'
 
-        # Read existing log data or initialize empty list
-        if os.path.exists(log_path):
-            with open(log_path, 'r') as f:
-                try:
-                    log_data = json.load(f)
-                except (json.JSONDecodeError, ValueError):
-                    log_data = []
-        else:
-            log_data = []
-        
-        # Append new data
-        log_data.append(input_data)
-        
-        # Write back to file with formatting
-        with open(log_path, 'w') as f:
-            json.dump(log_data, f, indent=2)
+        # Append new data as a single line to JSONL file
+        with open(log_file, 'a') as f:
+            json.dump(input_data, f)
+            f.write('\n')
         
         # Handle --chat switch (same as stop.py)
         if args.chat and 'transcript_path' in input_data:

--- a/.claude/hooks/user_prompt_submit.py
+++ b/.claude/hooks/user_prompt_submit.py
@@ -25,24 +25,12 @@ def log_user_prompt(session_id, input_data):
     # Ensure logs directory exists
     log_dir = Path("logs")
     log_dir.mkdir(parents=True, exist_ok=True)
-    log_file = log_dir / 'user_prompt_submit.json'
+    log_file = log_dir / 'user_prompt_submit.jsonl'
     
-    # Read existing log data or initialize empty list
-    if log_file.exists():
-        with open(log_file, 'r') as f:
-            try:
-                log_data = json.load(f)
-            except (json.JSONDecodeError, ValueError):
-                log_data = []
-    else:
-        log_data = []
-    
-    # Append the entire input data
-    log_data.append(input_data)
-    
-    # Write back to file with formatting
-    with open(log_file, 'w') as f:
-        json.dump(log_data, f, indent=2)
+    # Append new data as a single line to JSONL file
+    with open(log_file, 'a') as f:
+        json.dump(input_data, f)
+        f.write('\n')
 
 
 def validate_prompt(prompt):


### PR DESCRIPTION
The existing logging code reads the entire log file, adds one line, then writes back the entire log. By switching to JSONL format it's only necessary to write the one new line.